### PR TITLE
(BugFix) Initialization of Validators

### DIFF
--- a/contracts/Validatable.sol
+++ b/contracts/Validatable.sol
@@ -12,8 +12,11 @@ contract Validatable is Ownable {
 	mapping (address=>bool) public validators;
 
 	function Validatable(uint8 _requiredValidators,address[] _initialValidators) public {
+		require(_requiredValidators != 0);
+		require(_initialValidators.length >= _requiredValidators);
 		setRequiredValidators(_requiredValidators);
         for (uint i = 0; i < _initialValidators.length; i++) {
+	        require(!isValidator[_initialValidators[i]] && _initialValidators[i] != address(0));
         	addValidator(_initialValidators[i]);
         }
 	}


### PR DESCRIPTION
1. Make sure at least 1 signature being set
2. Prevent 0x0 addresses and double initialization of validators
3. Make sure there are enough validators provided to match its requirement